### PR TITLE
Add `__hash__` and `__eq__` for `ClientState`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -137,13 +137,20 @@ class ClientState:
 
     """
 
-    __slots__ = ("client_key", "wants_what", "last_seen", "versions")
+    __slots__ = ("client_key", "_hash", "wants_what", "last_seen", "versions")
 
     def __init__(self, client, versions=None):
         self.client_key = client
+        self._hash = hash(client)
         self.wants_what = set()
         self.last_seen = time()
         self.versions = versions or {}
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.client == other.client
 
     def __repr__(self):
         return "<Client %r>" % (self.client_key,)


### PR DESCRIPTION
Since we periodically collect `ClientState` objects in `set`s or as keys in `dict`, we need to make sure they are hashable, which means implementing these methods. Of course there is a fallback if we don't, but it is preferable to have these implemented as we would expect instead.